### PR TITLE
CON-390 Update all audit stack new version cloudcoreojsrunner.

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -311,7 +311,7 @@ const notifiers = AuditS3.getLetters();
 
 const JSONReportAfterGeneratingSuppression = AuditS3.getSortedJSONForAuditPanel();
 coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
-coreoExport('report', JSON.stringify(JSONReportAfterGeneratingSuppression['violations'));
+coreoExport('report', JSON.stringify(JSONReportAfterGeneratingSuppression['violations']));
 
 callback(notifiers);
   EOH

--- a/services/config.rb
+++ b/services/config.rb
@@ -250,7 +250,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-s3" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.8.9"
+                   :version => "1.9.0"
                },
                {
                    :name => "js-yaml",

--- a/services/config.rb
+++ b/services/config.rb
@@ -251,7 +251,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-s3" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.9.0"
+                   :version => "1.9.0-beta.2"
                },
                {
                    :name => "js-yaml",

--- a/services/config.rb
+++ b/services/config.rb
@@ -250,7 +250,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-s3" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.8.4"
+                   :version => "1.8.9"
                },
                {
                    :name => "js-yaml",
@@ -258,6 +258,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-s3" do
                }       ])
   json_input '{ "composite name":"PLAN::stack_name",
                 "plan name":"PLAN::name",
+                "cloud account name": "PLAN::cloud_account_name",
                 "violations": COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.report}'
   function <<-EOH
  
@@ -305,9 +306,9 @@ const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG,
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
 const AuditS3 = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
-const notifiers = AuditS3.getNotifiers();
+const notifiers = AuditS3.getLetters();
 
-const JSONReportAfterGeneratingSuppression = AuditS3.getJSONForAuditPanel();
+const JSONReportAfterGeneratingSuppression = AuditS3.getSortedJSONForAuditPanel();
 coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
 
 callback(notifiers);

--- a/services/config.rb
+++ b/services/config.rb
@@ -238,6 +238,7 @@ coreo_uni_util_variables "s3-update-planwide-1" do
   action :set
   variables([
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.results' => 'COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.report'},
+                {'COMPOSITE::coreo_uni_util_variables.s3-planwide.report' => 'COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.report'},
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.number_violations'},
 
             ])

--- a/services/config.rb
+++ b/services/config.rb
@@ -301,12 +301,12 @@ const ALLOW_EMPTY = "${AUDIT_AWS_S3_ALLOW_EMPTY}";
 const SEND_ON = "${AUDIT_AWS_S3_SEND_ON}";
 const SHOWN_NOT_SORTED_VIOLATIONS_COUNTER = false;
 
-const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG,
+const SETTINGS = { NO_OWNER_EMAIL, OWNER_TAG,
    ALLOW_EMPTY, SEND_ON, 
   SHOWN_NOT_SORTED_VIOLATIONS_COUNTER};
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
-const AuditS3 = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
+const AuditS3 = new CloudCoreoJSRunner(JSON_INPUT, SETTINGS);
 const notifiers = AuditS3.getLetters();
 
 const JSONReportAfterGeneratingSuppression = AuditS3.getSortedJSONForAuditPanel();

--- a/services/config.rb
+++ b/services/config.rb
@@ -310,7 +310,6 @@ const AuditS3 = new CloudCoreoJSRunner(JSON_INPUT, SETTINGS);
 const notifiers = AuditS3.getLetters();
 
 const JSONReportAfterGeneratingSuppression = AuditS3.getSortedJSONForAuditPanel();
-const JSONReportAfterGeneratingSuppression = JSONReportAfterGeneratingSuppression['violations'];
 coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
 coreoExport('report', JSON.stringify(JSONReportAfterGeneratingSuppression['violations'));
 

--- a/services/config.rb
+++ b/services/config.rb
@@ -322,7 +322,7 @@ coreo_uni_util_variables "s3-update-planwide-3" do
   action :set
   variables([
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport'},
-                {'COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport'},
+                {'COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport.violations'},
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.table'}
             ])
 end

--- a/services/config.rb
+++ b/services/config.rb
@@ -310,7 +310,9 @@ const AuditS3 = new CloudCoreoJSRunner(JSON_INPUT, SETTINGS);
 const notifiers = AuditS3.getLetters();
 
 const JSONReportAfterGeneratingSuppression = AuditS3.getSortedJSONForAuditPanel();
+const JSONReportAfterGeneratingSuppression = JSONReportAfterGeneratingSuppression['violations'];
 coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+coreoExport('report', JSON.stringify(JSONReportAfterGeneratingSuppression['violations'));
 
 callback(notifiers);
   EOH
@@ -322,7 +324,7 @@ coreo_uni_util_variables "s3-update-planwide-3" do
   action :set
   variables([
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport'},
-                {'COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport.violations'},
+                {'COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.report'},
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.table'}
             ])
 end

--- a/services/config.rb
+++ b/services/config.rb
@@ -322,6 +322,7 @@ coreo_uni_util_variables "s3-update-planwide-3" do
   action :set
   variables([
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport'},
+                {'COMPOSITE::coreo_uni_util_variables.s3-planwide.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport'},
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.table'}
             ])
 end

--- a/services/config.rb
+++ b/services/config.rb
@@ -251,7 +251,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-s3" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.9.0-beta.2"
+                   :version => "1.9.0-beta.3"
                },
                {
                    :name => "js-yaml",

--- a/services/config.rb
+++ b/services/config.rb
@@ -371,6 +371,7 @@ coreo_uni_util_notify "advise-s3-rollup" do
   payload '
 composite name: PLAN::stack_name
 plan name: PLAN::name
+cloud account name: PLAN::cloud_account_name
 COMPOSITE::coreo_uni_util_jsrunner.tags-rollup-s3.return
   '
   payload_type 'text'

--- a/services/config.rb
+++ b/services/config.rb
@@ -322,7 +322,7 @@ coreo_uni_util_variables "s3-update-planwide-3" do
   action :set
   variables([
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport'},
-                {'COMPOSITE::coreo_uni_util_variables.s3-planwide.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport'},
+                {'COMPOSITE::coreo_aws_rule_runner_s3.advise-s3.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.JSONReport'},
                 {'COMPOSITE::coreo_uni_util_variables.s3-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-s3.table'}
             ])
 end


### PR DESCRIPTION
PLA-3163 Engine does not support empty rules array
CON-287 Audit reports in WebUI and email don't list which AWS account being run on
CON-318 display meta_ attributes on cards
CON-334 add notifiers and jsrunner structures to the AWS config composite
CON-376 Report Emails: Update '# Resources' on cards to '# Cloud Objects'

Please note that this engine fix (https://bitbucket.org/cloudcoreo/engine/pull-requests/471) was merged only to master branch. If you run audit composites on the engine's dev branch it will give you the following error: "There's no rule named '' defined". So I guess we need to merge this fix to dev branch also. In master branch audit composites run correctly.